### PR TITLE
Add python3-gnupg dependency

### DIFF
--- a/keylime.spec
+++ b/keylime.spec
@@ -28,6 +28,7 @@ Requires: python3-simplejson
 Requires: python3-sqlalchemy
 Requires: python3-requests
 Requires: python3-zmq
+Requires: python3-gnupg
 Requires: tpm2-tss
 Requires: tpm2-tools
 Requires: tpm2-abrmd


### PR DESCRIPTION
The agent requires python-gnupg.  This requirement is also explicit in
requirements.txt.